### PR TITLE
Fixed URL for app statistic download

### DIFF
--- a/lib/googleplay_scraper/scraper.rb
+++ b/lib/googleplay_scraper/scraper.rb
@@ -140,13 +140,12 @@ module GooglePlayScraper
     #   application statics zip data
     #
     def get_appstats(package, start_day, end_day)
-      dim = "overall,country,language,os_version,device,app_version,carrier&met=daily_device_installs,active_device_installs,daily_user_installs,total_user_installs,active_user_installs,daily_device_uninstalls,daily_user_uninstalls,daily_device_upgrades"
-
-      url = "https://play.google.com/apps/publish/statistics/download"
+      dim = "overall,country,language,os_version,device,app_version,carrier&met=active_device_installs,daily_device_installs,daily_device_uninstalls,daily_device_upgrades,active_user_installs,total_user_installs,daily_user_installs,daily_user_uninstalls,daily_avg_rating,total_avg_rating"
+      url = "https://play.google.com/apps/publish/v2/statistics/download"
       url += "?package=#{package}"
       url += "&sd=#{start_day}&ed=#{end_day}"
       url += "&dim=#{dim}"
-      url += "&dev_acc=#{@config.dev_acc}"
+      #url += "&dev_acc=#{@config.dev_acc}"
 
       puts url
       try_get(url)


### PR DESCRIPTION
Google seems to have changed the URL, I could not retrieve app statistics with your code. I have updated the URL. I don not not have any apps for sale, thus I could not check these URLs, but I guess they have changed as well.

Philipp
